### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/disasm-lib/disasm_x86.c
+++ b/disasm-lib/disasm_x86.c
@@ -2157,8 +2157,7 @@ HasSpecialExtension:
 				// If there is both a base and index register, the Result will probably be too wrong
 				// to even guess
 				else if (X86Instruction->HasFullDisplacement && 
-					 ((X86Instruction->HasBaseRegister && !X86Instruction->HasIndexRegister) ||
-					 (!X86Instruction->HasBaseRegister && X86Instruction->HasIndexRegister)))
+					 (X86Instruction->HasBaseRegister != X86Instruction->HasIndexRegister))
 				{
 					assert(Operand1->Length <= 0xFF);
 					if (!X86Instruction->Scale)
@@ -2199,8 +2198,7 @@ HasSpecialExtension:
 				// If there is both a base and index register, the Result will probably be too wrong
 				// to even guess
 				else if (X86Instruction->HasFullDisplacement &&
-					((X86Instruction->HasBaseRegister && !X86Instruction->HasIndexRegister) ||
-					 (!X86Instruction->HasBaseRegister && X86Instruction->HasIndexRegister)))
+					(X86Instruction->HasBaseRegister != X86Instruction->HasIndexRegister))
 				{
 					//DISASM_OUTPUT(("[0x%08I64X] Scale %d, displacement 0x%08I64x\n", VIRTUAL_ADDRESS, X86Instruction->Scale, X86Instruction->Displacement));
 					if (!X86Instruction->Scale)
@@ -2294,8 +2292,7 @@ HasSpecialExtension:
 			// If there is both a base and index register, the Result will probably be too wrong
 			// to even guess
 			else if (Operand->Flags & OP_GLOBAL && 
-				((X86Instruction->HasBaseRegister && !X86Instruction->HasIndexRegister) ||
-				 (!X86Instruction->HasBaseRegister && X86Instruction->HasIndexRegister)))
+				(X86Instruction->HasBaseRegister != X86Instruction->HasIndexRegister))
 			{
 				DISASM_OUTPUT(("[0x%08I64X] Data reference (scale %d, size %d, displacement 0x%08I64x)\n", VIRTUAL_ADDRESS, X86Instruction->Scale, Operand->Length, X86Instruction->Displacement));
 				if (!X86Instruction->Scale)


### PR DESCRIPTION
V728 An excessive check can be simplified. The '(A && !B) || (!A && B)' expression is equivalent to the 'bool(A) != bool(B)' expression. disasm_x86.c 2160, 2202, 2297