### PR TITLE
Compilation-fix for VS 2019

### DIFF
--- a/disasm-lib/cpu.h
+++ b/disasm-lib/cpu.h
@@ -4,11 +4,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#pragma pack(push,1)
 
 #include <windows.h>
 #include "misc.h"
 
+// Windows SDK assumes default alignment.
+#pragma pack(push,1)
+   
 ////////////////////////////////////////////////////////
 // System descriptors
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
Windows assumes default alignment in their SDKs, so pacing needs to be done after `#include <windows.h>` or defining `WINDOWS_IGNORE_PACKING_MISMATCH`.