### PR TITLE
Fix for failing to detect { xor; jmp } locations in x64

### DIFF
--- a/mhook-lib/mhook.cpp
+++ b/mhook-lib/mhook.cpp
@@ -969,14 +969,23 @@ static DWORD DisassembleAndSkip(PVOID pFunction, DWORD dwMinLen, MHOOKS_PATCHDAT
         while ( (dwRet < dwMinLen) && (pins = GetInstruction(&dis, (ULONG_PTR)pLoc, pLoc, dwFlags)) ) 
         {
             ODPRINTF((L"mhooks: DisassembleAndSkip: %p:(0x%2.2x) %s", pLoc, pins->Length, pins->String));
-            if (pins->Type == ITYPE_RET     ) break;
-            if (pins->Type == ITYPE_BRANCH  ) break;
-            if (pins->Type == ITYPE_CALLCC  ) break;
-
+            if (pins->Type == ITYPE_RET     )   break;
+            if (pins->Type == ITYPE_BRANCHCC)   break;
+            if (pins->Type == ITYPE_CALL)       break;
+            if (pins->Type == ITYPE_CALLCC)     break;
+            
             #if defined _M_X64
                 bool bProcessRip = false;
+                // jmp to rip+imm32
+                if ((pins->Type == ITYPE_BRANCH) && (pins->OperandCount == 1) && (pins->X86.Relative) && (pins->X86.BaseRegister == AMD64_REG_RIP) && (pins->Operands[0].Flags & OP_IPREL))
+                {
+                    // rip-addressing "jmp [rip+imm32]"
+                    ODPRINTF((L"mhooks: DisassembleAndSkip: found OP_IPREL on operand %d with displacement 0x%x (in memory: 0x%x)", 1, pins->X86.Displacement, *(PDWORD)(pLoc + 3)));
+                    bProcessRip = true;
+                }
+            
                 // mov or lea to register from rip+imm32
-                if ((pins->Type == ITYPE_MOV || pins->Type == ITYPE_LEA) && (pins->X86.Relative) && 
+                else if ((pins->Type == ITYPE_MOV || pins->Type == ITYPE_LEA) && (pins->X86.Relative) && 
                     (pins->X86.OperandSize == 8) && (pins->OperandCount == 2) &&
                     (pins->Operands[1].Flags & OP_IPREL) && (pins->Operands[1].Register == AMD64_REG_RIP))
                 {

--- a/mhook-lib/mhook.cpp
+++ b/mhook-lib/mhook.cpp
@@ -971,7 +971,6 @@ static DWORD DisassembleAndSkip(PVOID pFunction, DWORD dwMinLen, MHOOKS_PATCHDAT
             ODPRINTF((L"mhooks: DisassembleAndSkip: %p:(0x%2.2x) %s", pLoc, pins->Length, pins->String));
             if (pins->Type == ITYPE_RET     )   break;
             if (pins->Type == ITYPE_BRANCHCC)   break;
-            if (pins->Type == ITYPE_CALL)       break;
             if (pins->Type == ITYPE_CALLCC)     break;
             
             #if defined _M_X64


### PR DESCRIPTION
Imported from the original repo, commit 56bc9ea8fe73dc6f2f36d7d017081f8717e6fb22