### PR TITLE
Convert mhook-lib source to plain C code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 add_definitions(-DNO_SANITY_CHECKS -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN)
 
 file(GLOB DisasmSrc disasm-lib/*.c disasm-lib/*.h)
-file(GLOB MhookSrc mhook-lib/*.cpp mhook-lib/*.h)
+file(GLOB MhookSrc mhook-lib/*.c mhook-lib/*.h)
 
 source_group("disasm-lib" FILES ${DisasmSrc})
 source_group("mhook-lib" FILES ${MhookSrc})

--- a/mhook-lib/mhook.h
+++ b/mhook-lib/mhook.h
@@ -18,20 +18,28 @@
 //FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
 //IN THE SOFTWARE.
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef _M_IX86
 #define _M_IX86_X64
 #elif defined _M_X64
 #define _M_IX86_X64
 #endif
 
-struct HOOK_INFO
+typedef struct
 {
     PVOID *ppSystemFunction;    // pointer to pointer to function to be hooked
     PVOID pHookFunction;        // hook function
-};
+} HOOK_INFO;
 
 // returns number of successfully set hooks
 int Mhook_SetHookEx(HOOK_INFO* hooks, int hookCount);
 BOOL Mhook_SetHook(PVOID *ppSystemFunction, PVOID pHookFunction);
 int Mhook_UnhookEx(PVOID** hooks, int hookCount);
 BOOL Mhook_Unhook(PVOID *ppHookedFunction);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
While using this library, I noticed that the source code to mhook-lib did not really require any C++ features. With this PR, it should be a lot easier to link to mhook in a C library (perhaps to create bindings for external languages). In my case, I wanted to limit the inclusion of C++ code to keep the footprint of my code small.